### PR TITLE
vigra/meta.yaml: Make a note about the `convolveOneDimension` commit.

### DIFF
--- a/vigra/meta.yaml
+++ b/vigra/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: git://github.com/ukoethe/vigra.git
-  git_tag: 35e5d4aed380087d75e206348d1648d9ad9cf1e6 # 2015-07-16
+  git_tag: 35e5d4aed380087d75e206348d1648d9ad9cf1e6 # 2015-07-16, must include commit e4946fe0387bf9086ef074da6912c763f832c053
 
 build:
   script_env:


### PR DESCRIPTION
Explicitly note a requirement for [`nanshe`](https://github.com/jakirkham/nanshe) when using[`VIGRA`](https://github.com/ukoethe/vigra). Split out from ( https://github.com/ilastik/ilastik-build-conda/pull/1 ).
