### PR TITLE
ilastik-meta: Set FONTCONFIG_{PATH,FILE}

### DIFF
--- a/ilastik-meta/build.sh
+++ b/ilastik-meta/build.sh
@@ -60,6 +60,11 @@ export QT_PLUGIN_PATH=\${PREFIX}/plugins
 # Disable the checks.
 export MALLOC_CHECK_=0
 
+# fontconf determines the default paths for configuration files during compile time
+# make sure to update these to match the local system
+export FONTCONFIG_PATH=\${PREFIX}/etc/fonts/
+export FONTCONFIG_FILE=\${PREFIX}/etc/fonts/fonts.conf
+
 # Launch the ilastik entry script, and pass along any commmand line args.
 \${PREFIX}/bin/python \${PREFIX}/ilastik-meta/ilastik/ilastik.py "\$@"
 EOF


### PR DESCRIPTION
Starting the ilastik 1.1.7 binary release using run_ilastik.sh results in a ugly default font and the following message on the console in linux:

`Fontconfig error: Cannot load default config file`

Digging a bit with strace reveals the following problem:

```
access("/miniconda/envs/ilastik-release/etc/fonts/fonts.conf", R_OK) = -1 ENOENT (No such file or directory)
write(2, "Fontconfig error: ", 18Fontconfig error: )      = 18
```

This happens because fontconfig looks for fonts.conf in ${PREFIX}/etc with ${PREFIX} evaluated at compile time. While this file exists on the machine where ilastik was built it doesn't on my machine.

This can be fixed by adding the following two lines to run_ilastik.sh:

```
export FONTCONFIG_PATH=${PREFIX}/etc/fonts/
export FONTCONFIG_FILE=${PREFIX}/etc/fonts/fonts.conf
```
