### PR TITLE
boost: add support for python >=3

### DIFF
--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -12,9 +12,10 @@ source:
     - 1.55.0_patches/0005-Boost.S11n-include-missing-algorithm.patch  [osx]
 
 build:
-  number: 5
+  {% set build_num = 5 %}
+  number: {{build_num}}
   detect_binary_files_with_prefix: true
-  string: py{{CONDA_PY}}
+  string: py{{CONDA_PY}}_{{build_num}}
 
 requirements:
   build:

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
   number: 5
   detect_binary_files_with_prefix: true
+  string: py{{CONDA_PY}}
 
 requirements:
   build:

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -21,11 +21,13 @@ requirements:
   build:
     - gcc 4.8.5 # [linux]
     - gcc 4.8.5 # [osx]
-    - python
+    - python 2.7*|3.5*
+    - python {{PY_VER}}*
     - zlib
 
   run:
     - libgcc
+    - python {{PY_VER}}*
 
 about:
   home: http://www.boost.org/


### PR DESCRIPTION
boost needs to be compiled independently for python 2 and 3. this is required for the WIP aiming to add python 3 support to vigra.
