### PR TITLE
Pgmlink structured learning update

### DIFF
--- a/pgmlink-structured-learning/meta.yaml
+++ b/pgmlink-structured-learning/meta.yaml
@@ -4,10 +4,10 @@ package:
 
 source:
     git_url: https://github.com/ilastik/pgmlink
-    git_tag: learning
+    git_tag: master
 
 build:
-  {% set build_num = 2 %}
+  {% set build_num = 3 %}
   number: {{ build_num }}
 
   #

--- a/pgmlink-structured-learning/meta.yaml
+++ b/pgmlink-structured-learning/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - boost 1.55.0
     - python 2.7*
     - numpy >=1.9,{{NPY_VER}}*
-    - vigra
+    - vigra 1.10
     - opengm-structured-learning
     - mlpack
     - lemon
@@ -47,7 +47,7 @@ requirements:
     - boost 1.55.0
     - python {{PY_VER}}*
     - numpy  {{NPY_VER}}*
-    - vigra
+    - vigra 1.10
     - mlpack
     - lemon
     - libxml2


### PR DESCRIPTION
Switched tag from `pgmlink-structured-learning` to `master`, bumped up the build number to 3, and changed the vigra version to 1.10 in the file `meta.yaml`.
