### PR TITLE
Tracking libs update

### DIFF
--- a/ilastik-versions/meta.yaml
+++ b/ilastik-versions/meta.yaml
@@ -20,11 +20,9 @@ build:
 requirements:
   run:
     - ann                       1.1.2     
-    - armadillo                 6.500.5   
     #- blist                     1.3.6 # Only needed by deprecated operators     
     - boost                     1.55.0    
     #- cylemon                   1         
-    - dlib                      18.16
     - decorator                 3.4.0
     - dpct                      1.2
     - faulthandler              2.4       
@@ -51,7 +49,6 @@ requirements:
     - libxml2                   2.9.0     
     - mamutexport               0.2.0
     - matplotlib                1.5.1     
-    - mlpack                    1.0.8.99     
 
 {% if WITH_SOLVERS %}
     - multi-hypotheses-tracking-with-gurobi 1.1.3
@@ -78,9 +75,13 @@ requirements:
     - openssl                   1.0.2j    
     - pandas                    0.18.1
 
-{% if WITH_SOLVERS %}
-    - pgmlink                   1.3.post4       
-{% endif %}
+# {% if WITH_SOLVERS %}
+# Only used on windows now!
+    # - pgmlink                   1.3.post4       
+    # - armadillo                 6.500.5   
+    # - dlib                      18.16
+    # - mlpack                    1.0.8.99     
+# {% endif %}
 
     - pillow                    3.0.0
     - pip                       6.1.1     

--- a/ilastik-versions/meta.yaml
+++ b/ilastik-versions/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     #- cylemon                   1         
     - dlib                      18.16
     - decorator                 3.4.0
-    - dpct                      1.1.post4
+    - dpct                      1.2
     - faulthandler              2.4       
     - fftw                      3.3.4     
     - freetype                  2.5.2     
@@ -34,7 +34,7 @@ requirements:
     - greenlet                  0.4.6     
     - h5py                      2.7.0     
     - hdf5                      1.8.17
-    - hytra                     1.1.1
+    - hytra                     1.1.3
     - iiboost                   0.2.post2       
     - ilastik-feature-selection 0.123.post9
     - ilastiktools              0.2       
@@ -53,8 +53,8 @@ requirements:
     - mlpack                    1.0.8.99     
 
 {% if WITH_SOLVERS %}
-    - multi-hypotheses-tracking-with-gurobi 1.1.2
-    - multi-hypotheses-tracking-with-cplex  1.1.2
+    - multi-hypotheses-tracking-with-gurobi 1.1.3
+    - multi-hypotheses-tracking-with-cplex  1.1.3
 {% endif %}
 
     - networkx                  1.11

--- a/ilastik-versions/meta.yaml
+++ b/ilastik-versions/meta.yaml
@@ -49,6 +49,7 @@ requirements:
     - libpng                    1.6.17
     - libtiff                   4.0.6
     - libxml2                   2.9.0     
+    - mamutexport               0.2.0
     - matplotlib                1.5.1     
     - mlpack                    1.0.8.99     
 


### PR DESCRIPTION
Require latest versions of tracking libraries in `ilastik-versions`.

These did update, and for convenience the required build commands (only MHT needs a solver):
* dpct: https://github.com/chaubold/dpct, `conda build conda-recipe/ -c ilastik`
* hytra: https://github.com/chaubold/hytra, `conda build conda-recipe/ -c ilastik`
* multiHypoTracking: https://github.com/chaubold/multiHypothesesTracking, `WITH_CPLEX=0 WITH_GUROBI=1 GUROBI_ROOT_DIR=... conda build conda-recipe -c ilastik` etc.
* **NEW** mamutexport: https://github.com/Beinabih/MaMutConverter, `conda build conda-recipe/ -c ilastik`

Preliminary packages are already in my conda channel, tested and verified on linux by @k-dominik. But @JaimeIvanCervantes found some problem in hytra that he will fix today (the 1.1.3 tag referenced here doesn't exist yet!), so he will give the final OK, and then this PR is ready.

I also commented out `pgmlink` and the packages which I think are only needed by pgmlink and nobody else, because even the structured learning workflow has moved to `hytra` now, hence `pgmlink` is only required on windows now.