### PR TITLE
Bugfix remove-obsolete-libstdcxx.sh

### DIFF
--- a/libgcc/remove-obsolete-libstdcxx.sh
+++ b/libgcc/remove-obsolete-libstdcxx.sh
@@ -30,8 +30,7 @@ parse_libstdcxx_version() {
     # but 'grep' is more likely to be installed on an arbitrary linux machine.)
     LIBSTDCXX_VERSION=$(grep -ao 'GLIBCXX_[0-9][0-9]\?\.[0-9][0-9]\?\(\.[0-9][0-9]\?\)\?' $LIBSTDCXX_SO \
                         | cut -b 9- \
-                        | python -c "import sys; sys.stdout.write(str(sorted(sys.stdin.split(), key=lambda s: s.split('.'))[-1]))")
-
+                        | sort -t'.' -n -k3) 
     echo $LIBSTDCXX_VERSION
 }
 


### PR DESCRIPTION
The python part had some issues
2. `sys.stdin` is `_io.TextIOWrapper` object in python3 and `file` object in python2. It does not have a `split()` method. Should've been changed to `sys.stdin.read()`. However, 
1. It will sort taking the values as strings and not numerically. So if the GLIBCXX looks like
```
3.4
3.4.1
3.4.2
3.4.3
3.4.4
3.4.5
3.4.6
3.4.7
3.4.8
3.4.9
3.4.10
3.4.11
3.4.12
3.4.13
3.4.14
3.4.15
3.4.16
3.4.17
3.4.18
3.4.19
3.4.20
3.4.21
```
It will pick `3.4.9`  as it is greatest lexicograpically. So I replaced it with numeric `sort`.