### PR TITLE
Update meta.yaml

### DIFF
--- a/ilastik-dependencies/meta.yaml
+++ b/ilastik-dependencies/meta.yaml
@@ -12,7 +12,7 @@ package:
     version: 1.3
 
 build:
-  number: 1
+  number: 2
   track_features:
     # on osx we need to make sure that we install the numpy versions with openblas instead of mkl to prevent clashes with cplex
     - blas_openblas #[osx] 

--- a/ilastik-dependencies/meta.yaml
+++ b/ilastik-dependencies/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - h5py                      >=2.7.0     
     - hdf5                      >=1.8.17
     - jsonschema                
-    - networkx                  
+    - networkx                  1.11          # TODO API change in 2.0
     - nose                      
     - psutil                    
     - pyqt                      5.6*


### PR DESCRIPTION
fixed networkx version for now

the networkx api has changed from `1.11` to `2.0`. We should address those changes soon, but for now just fix the version.