### PR TITLE
fixed error starting up ilastik from distributed archive

### DIFF
--- a/ilastik-launch/run_ilastik.sh
+++ b/ilastik-launch/run_ilastik.sh
@@ -11,6 +11,9 @@ else
     export PREFIX=$(dirname "$(readlink -f $0)")
 fi
 
+# make sure we use the correct python in subsequent scripts (/bin/remove-obsolete-libstdcxx.sh)
+export PATH=${PREFIX}/bin:${PATH}
+
 # Do not use the user's previous LD_LIBRARY_PATH settings because they can cause conflicts.
 # Start with an empty LD_LIBRARY_PATH
 if [[ $LD_LIBRARY_PATH != "" ]]; then


### PR DESCRIPTION
I have encountered an issue after upgrading to miniconda3 and thus, having python3 in my path with the `run_ilastik.sh` script. It tries to run the `remove-obsolete-libstdcxx.sh` in which we implicitly assume python2. So, enforcing the shipped version via `PATH` fixes this on my system.

Fixes https://github.com/ilastik/ilastik/issues/1593