### PR TITLE
Revert "Fix ilastik-dependencies version fetching"

### DIFF
--- a/create-tarball.sh
+++ b/create-tarball.sh
@@ -53,7 +53,7 @@ function latest_build()
     VERSION_AND_BUILD=$(conda search -f $@ \
                         | tail -n1 \
                         | python -c 'import sys; print("=".join(sys.stdin.read().split()[:2]))')
-    echo "$VERSION_AND_BUILD"
+    echo "$1=$VERSION_AND_BUILD"
 }
 
 # Create new ilastik-release environment and install all ilastik dependencies to it.

--- a/osx-packages/create-osx-app.sh
+++ b/osx-packages/create-osx-app.sh
@@ -58,7 +58,7 @@ function latest_build()
     VERSION_AND_BUILD=$(conda search -f $@ \
                         | tail -n1 \
                         | python -c 'import sys; print("=".join(sys.stdin.read().split()[:2]))')
-    echo "$VERSION_AND_BUILD"
+    echo "$1=$VERSION_AND_BUILD"
 }
 
 # Create new ilastik-release environment and install all ilastik dependencies to it.


### PR DESCRIPTION
Format of the table returned by conda search seems to have changed again

This reverts commit 197a9db351034e26ce07c68f07a2c3b70843dcc3.