### PR TITLE
Use system compilers on linux

### DIFF
--- a/lemon/build.sh
+++ b/lemon/build.sh
@@ -20,12 +20,13 @@
 if [[ `uname` == 'Darwin' ]]; then
     export CC=clang
     export CXX=clang++
-
+    LEMON_CXX_FLAGS="${CXXFLAGS}"
     # Pursuant to Item 2 above, replace the tools/CMakeLists.txt with an empty file.
     echo "" > tools/CMakeLists.txt
 else
-    export CC=${PREFIX}/bin/gcc
-    export CXX=${PREFIX}/bin/g++
+    export CC=gcc
+    export CXX=g++
+    LEMON_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${CXXFLAGS}"
 fi
 
 mkdir build
@@ -42,8 +43,7 @@ cmake .. \
     -DGLPK_LIBRARY= \
     -DGLPK_INCLUDE_DIR= \
     -DGLPK_ROOT_DIR= \
-
-#    -DCMAKE_CXX_FLAGS="${CXXFLAGS}"
+    -DCMAKE_CXX_FLAGS="${LEMON_CXX_FLAGS}" \
 #    -DCMAKE_CXX_LINKER_FLAGS="${CXX_LDFLAGS}"
 
 VERBOSE=1 make -j${CPU_COUNT}

--- a/lemon/build.sh
+++ b/lemon/build.sh
@@ -26,7 +26,11 @@ if [[ `uname` == 'Darwin' ]]; then
 else
     export CC=gcc
     export CXX=g++
-    LEMON_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${CXXFLAGS}"
+    LEMON_CXX_FLAGS="${CXXFLAGS}"
+    # enable compilation without CXX abi to stay compatible with gcc < 5 built packages
+    if [[ ${DO_NOT_BUILD_WITH_CXX11_ABI} == '1' ]]; then
+        LEMON_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${LEMON_CXX_FLAGS}"
+    fi
 fi
 
 mkdir build

--- a/lemon/meta.yaml
+++ b/lemon/meta.yaml
@@ -18,6 +18,7 @@ build:
   number: 3
   msvc_compiler: 14.0 # [win]
   script_env:
+    # Control building with CXX11 abi
     - DO_NOT_BUILD_WITH_CXX11_ABI  # [linux]
 
 about:

--- a/lemon/meta.yaml
+++ b/lemon/meta.yaml
@@ -18,13 +18,6 @@ build:
   number: 3
   msvc_compiler: 14.0 # [win]
 
-requirements:
-  build:
-    - gcc 4.8.5 # [linux]
-
-  run:
-    - libgcc # [linux]
-
 about:
   home: http://lemon.cs.elte.hu/trac/lemon
   license: Boost

--- a/lemon/meta.yaml
+++ b/lemon/meta.yaml
@@ -17,6 +17,8 @@ build:
     - vc14 # [win]
   number: 3
   msvc_compiler: 14.0 # [win]
+  script_env:
+    - DO_NOT_BUILD_WITH_CXX11_ABI  # [linux]
 
 about:
   home: http://lemon.cs.elte.hu/trac/lemon

--- a/lemon/meta.yaml
+++ b/lemon/meta.yaml
@@ -15,7 +15,7 @@ source:
 build:
   features:
     - vc14 # [win]
-  number: 3
+  number: 4
   msvc_compiler: 14.0 # [win]
   script_env:
     # Control building with CXX11 abi

--- a/vigra/build.sh
+++ b/vigra/build.sh
@@ -13,7 +13,11 @@ if [[ `uname` == 'Darwin' ]]; then
 else
     export CC=gcc
     export CXX=g++
-    VIGRA_CXX_FLAGS="-std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0 -pthread ${CXXFLAGS}"
+    VIGRA_CXX_FLAGS="-std=c++11 -pthread ${CXXFLAGS}"
+    # enable compilation without CXX abi to stay compatible with gcc < 5 built packages
+    if [[ ${DO_NOT_BUILD_WITH_CXX11_ABI} == '1' ]]; then
+        VIGRA_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${VIGRA_CXX_FLAGS}"
+    fi
     DYLIB_EXT=so
 fi
 

--- a/vigra/build.sh
+++ b/vigra/build.sh
@@ -11,9 +11,9 @@ if [[ `uname` == 'Darwin' ]]; then
     VIGRA_CXX_FLAGS="-std=c++11 -stdlib=libc++ -I${PREFIX}/include" # I have no clue why this -I option is necessary on Mac.
     DYLIB_EXT=dylib
 else
-    export CC=${PREFIX}/bin/gcc
-    export CXX=${PREFIX}/bin/g++
-    VIGRA_CXX_FLAGS="-std=c++11 -pthread ${CXXFLAGS}"
+    export CC=gcc
+    export CXX=g++
+    VIGRA_CXX_FLAGS="-std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0 -pthread ${CXXFLAGS}"
     DYLIB_EXT=so
 fi
 
@@ -87,7 +87,6 @@ cmake ..\
 \
         -DJPEG_INCLUDE_DIR=${PREFIX}/include \
         -DJPEG_LIBRARY=${PREFIX}/lib/libjpeg.${DYLIB_EXT} \
-
 
 # BUILD
 if [[ `uname` == 'Darwin' ]]; then

--- a/vigra/meta.yaml
+++ b/vigra/meta.yaml
@@ -19,7 +19,7 @@ source:
 build:
   features:
     - vc14 # [win]
-  number: 6
+  number: 7
   msvc_compiler: 14.0 # [win]
 
   #
@@ -38,7 +38,7 @@ requirements:
     - python {{PY_VER}}*
     - numpy >=1.9,{{NPY_VER}}*
     - jpeg     9b
-    - libtiff  4.0.6
+    - libtiff  4.0.9
     - libpng   1.6.27
     - fftw     3.3*
     - hdf5     1.10.1
@@ -52,7 +52,7 @@ requirements:
     - python {{PY_VER}}*
     - numpy  {{NPY_VER}}*
     - jpeg     9*
-    - libtiff  4.0.6   # libtiff version must exactly match from the build (on osx, at least)
+    - libtiff  4.0.9   # libtiff version must exactly match from the build (on osx, at least)
     - libpng   >=1.6.27,<1.7
     - fftw     3.3*
     - hdf5     1.10.1

--- a/vigra/meta.yaml
+++ b/vigra/meta.yaml
@@ -29,6 +29,8 @@ build:
 
   script_env:
     - VIGRA_SKIP_TESTS
+    # Control building with CXX11 abi
+    - DO_NOT_BUILD_WITH_CXX11_ABI  # [linux]
 
 requirements:
   build:

--- a/vigra/meta.yaml
+++ b/vigra/meta.yaml
@@ -32,7 +32,6 @@ build:
 
 requirements:
   build:
-    - gcc 4.8.5 # [linux]
     - python 2.7*|3.5*|3.6*
     - python {{PY_VER}}*
     - numpy >=1.9,{{NPY_VER}}*
@@ -48,7 +47,6 @@ requirements:
     - nose
 
   run:
-    - libgcc   4.8* # [linux]
     - python {{PY_VER}}*
     - numpy  {{NPY_VER}}*
     - jpeg     9*


### PR DESCRIPTION
This is related to allowing dependencies to be built with newer gcc than the one available through conda (4.8.5 atm), in particular, recent nifty changes forced us to use a newer compiler.

See some more background on this in https://github.com/ilastik/ilastik-publish-packages/issues/2

In order to use the system compilers this PR removes

* references to `gcc`, `libgcc` in the respective `meta.yaml` files
* points to the correct compiler in `build.sh`
* introduces an environment variable `DO_NOT_BUILD_WITH_CXX11_ABI` that is used in the build process to enable building with `-D_GLIBCXX_USE_CXX11_ABI=0` to enable compatibility with the "old" gcc stdlib abi.