### PR TITLE
fix latest_build function

### DIFF
--- a/create-tarball.sh
+++ b/create-tarball.sh
@@ -53,7 +53,7 @@ function latest_build()
     VERSION_AND_BUILD=$(conda search -f $@ \
                         | tail -n1 \
                         | python -c 'import sys; print("=".join(sys.stdin.read().split()[:2]))')
-    echo "$1=$VERSION_AND_BUILD"
+    echo "$VERSION_AND_BUILD"
 }
 
 # Create new ilastik-release environment and install all ilastik dependencies to it.

--- a/osx-packages/create-osx-app.sh
+++ b/osx-packages/create-osx-app.sh
@@ -58,7 +58,7 @@ function latest_build()
     VERSION_AND_BUILD=$(conda search -f $@ \
                         | tail -n1 \
                         | python -c 'import sys; print("=".join(sys.stdin.read().split()[:2]))')
-    echo "$1=$VERSION_AND_BUILD"
+    echo "$VERSION_AND_BUILD"
 }
 
 # Create new ilastik-release environment and install all ilastik dependencies to it.


### PR DESCRIPTION
this got changed in the past back and forth, not sure
if it's conda versions that introduce the error or if something
else on our side was inconsistend. But I was tired of changing
this every time I do a package ;)