### PR TITLE
Add pyfeast recipe

### DIFF
--- a/pyfeast/build.sh
+++ b/pyfeast/build.sh
@@ -1,0 +1,2 @@
+python setup.py build
+python setup.py install

--- a/pyfeast/fix-toolbox-location.patch
+++ b/pyfeast/fix-toolbox-location.patch
@@ -1,0 +1,12 @@
+--- feast.py	2016-03-08 16:35:49.000000000 -0500
++++ feast.py	2016-03-08 16:33:14.000000000 -0500
+@@ -21,7 +21,8 @@
+ import numpy as np
+ import ctypes as c
+ 
+-libFSToolbox = c.CDLL("libFSToolbox.so"); 
++import sys
++libFSToolbox = c.CDLL(sys.prefix + "/lib/libFSToolbox.so"); 
+ 
+ def BetaGamma(data, labels, n_select, beta=1.0, gamma=1.0):
+   """

--- a/pyfeast/meta.yaml
+++ b/pyfeast/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   number: 3
+  skip: true  # [win]
 
 requirements:
   build:

--- a/pyfeast/meta.yaml
+++ b/pyfeast/meta.yaml
@@ -1,0 +1,38 @@
+package:
+  name: pyfeast
+  version: "1.1.post1"
+
+source:
+  #git_url: https://github.com/mutantturkey/PyFeast
+  #git_tag: 556ae3823ce8105668cf22bb966acdec1ef954e6 # 2014-10-27
+
+  git_url: https://github.com/stuarteberg/PyFeast
+  git_tag: 57d808de2ca8832bf3d579358d6c883a8c3e31ba
+  
+  patches:
+    - fix-toolbox-location.patch
+
+build:
+  number: 2
+
+requirements:
+  build:
+    - python 2.7*|3.5*
+    - python {{PY_VER}}*
+    - numpy
+    - feast >=1.1.1
+  
+  run:
+    - python {{PY_VER}}*
+    - numpy
+    - feast >=1.1.1
+
+test:
+  requires:
+    - scikit-learn
+
+about:
+  home: https://github.com/mutantturkey/PyFeast
+  license: GPLv3
+  license_file: LICENSE.txt
+  summary: 'A Python interface to the Feature Selection Toolkit, contains JMI, BetaGamma, CMIM, CondMI, DISR, ICAP, and mRMR'

--- a/pyfeast/meta.yaml
+++ b/pyfeast/meta.yaml
@@ -13,23 +13,28 @@ source:
     - fix-toolbox-location.patch
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
-    - python 2.7*|3.5*
-    - python {{PY_VER}}*
-    - numpy
+    - python {{ python }}
+    - numpy {{ numpy }}
     - feast >=1.1.1
   
   run:
-    - python {{PY_VER}}*
+    - python
     - numpy
     - feast >=1.1.1
 
 test:
+  source_files:
+    - test/*
+  commands:
+    - python test/test.py
   requires:
     - scikit-learn
+  imports:
+    - feast
 
 about:
   home: https://github.com/mutantturkey/PyFeast

--- a/pyfeast/run_test.sh
+++ b/pyfeast/run_test.sh
@@ -1,4 +1,0 @@
-cd "${SRC_DIR}"
-
-# The test just prints pass/fail messages.
-python test/test.py | (! grep -i fail)

--- a/pyfeast/run_test.sh
+++ b/pyfeast/run_test.sh
@@ -1,0 +1,4 @@
+cd "${SRC_DIR}"
+
+# The test just prints pass/fail messages.
+python test/test.py | (! grep -i fail)


### PR DESCRIPTION
resurrected the old `pyfeast` recipe. Thanks @stuarteberg , I found a commit that was already python 3 ready.

Furthermore I updated the recipe to use `cbc.yaml`, and made the tests work.

fixes https://github.com/ilastik/ilastik-feature-selection/issues/3

_edit: while the tests for `ilastik-feature-selection` can now be run, they still fail: https://github.com/ilastik/ilastik-feature-selection/issues/1_

Todo:

 * [x] disable build on windows