### PR TITLE
added output of manifest file

### DIFF
--- a/windows-installer/ilastik-package/LICENSE.txt
+++ b/windows-installer/ilastik-package/LICENSE.txt
@@ -1,5 +1,5 @@
 
- ilastik is Copyright (C) 2017 The ilastik Team <team@ilastik.org>
+ ilastik is Copyright (C) 2018 The ilastik Team <team@ilastik.org>
 
  You may use, distribute and copy ilastik under the terms of GNU General
  Public License version 2, which is displayed below, or any later version

--- a/windows-installer/ilastik-package/ilastik.iss.in
+++ b/windows-installer/ilastik-package/ilastik.iss.in
@@ -18,6 +18,7 @@ OutputBaseFilename=ilastik-@VERSION@-win64
 LicenseFile=LICENSE.txt
 SourceDir=..
 OutputDir=package
+OutputManifestFile=ilastik-@VERSION@-manifest.txt
 
 [Files]
 Source: "LICENSE.txt"; DestDir: "{app}"


### PR DESCRIPTION
In order to be able to perform some checks against the installed files, the installer is now configured to output a `manifest` text file that includes all copied file names.