### PR TITLE
fix sklearn, due to api change

### DIFF
--- a/ilastik-dependencies/conda_build_config.yaml
+++ b/ilastik-dependencies/conda_build_config.yaml
@@ -12,6 +12,8 @@ pyqt:
   - 5.6
 qt:
   - 5.6
+sklearn:
+  - 0.19
 tifffile:
   - 0.4.post2
 vigra:

--- a/ilastik-dependencies/meta.yaml
+++ b/ilastik-dependencies/meta.yaml
@@ -12,7 +12,7 @@ package:
     version: 1.3.2
 
 build:
-  number: 1
+  number: 2
   track_features:
     # on osx we need to make sure that we install the numpy versions with openblas instead of mkl to prevent clashes with cplex
     - blas_openblas #[osx] 
@@ -47,7 +47,7 @@ requirements:
     - readline                                 # [not win]
     - requests                  
     - scikit-image              
-    - scikit-learn              
+    - scikit-learn              {{ sklearn }}*
     - setuptools                
     - matplotlib
     - mkl                       {{ mkl }}      # [win]


### PR DESCRIPTION
sklearn removes `cross_validation` in `0.20` (it gets moved to `model_selection`. Furthermore there are some changes on the iterators, so it's not a text-replace). 