### PR TITLE
Fix skimage win

### DIFF
--- a/ilastik-dependencies/conda_build_config.yaml
+++ b/ilastik-dependencies/conda_build_config.yaml
@@ -14,6 +14,8 @@ qt:
   - 5.6
 sklearn:
   - 0.19
+skimage:
+  - 0.13  # [win]
 tifffile:
   - 0.4.post2
 vigra:

--- a/ilastik-dependencies/meta.yaml
+++ b/ilastik-dependencies/meta.yaml
@@ -12,7 +12,7 @@ package:
     version: 1.3.2
 
 build:
-  number: 2
+  number: 3
   track_features:
     # on osx we need to make sure that we install the numpy versions with openblas instead of mkl to prevent clashes with cplex
     - blas_openblas #[osx] 
@@ -45,8 +45,11 @@ requirements:
     - qimage2ndarray            
     - qt                        {{ qt }}
     - readline                                 # [not win]
-    - requests                  
-    - scikit-image              
+    - requests
+    - scikit-image
+    # need to specify version on windows, due to
+    # RuntimeError: module compiled against API version 0xc but this version of numpy is 0xa
+    - scikit-image              {{ skimage }}*  # [win]
     - scikit-learn              {{ sklearn }}*
     - setuptools                
     - matplotlib

--- a/pyfeast/conda_build_config.yaml
+++ b/pyfeast/conda_build_config.yaml
@@ -1,0 +1,8 @@
+numpy:
+  - 1.12
+python:
+  - 3.6
+
+pin_run_as_build:
+  numpy: x.x
+  python: x.x


### PR DESCRIPTION
`skimage` `v0.14` seems to be built against `numpy 1.15` on windows. In order to use our stack with `numpy 1.12`, we fix the version to `0.13`, for now.

reference error:

```pytb
RuntimeError: module compiled against API version 0xc but this version of numpy is 0xa
```