### PR TITLE
Add z5py recipe

### DIFF
--- a/z5/bld.bat
+++ b/z5/bld.bat
@@ -1,0 +1,21 @@
+rem apply xtensor patches
+git apply conda-recipe/patches/xtensor-copysign.patch --verbose --unsafe-paths
+git apply conda-recipe/patches/xtensor-sizet.patch --verbose --unsafe-paths
+
+mkdir build
+cd build
+
+set CONFIGURATION=Release
+
+cmake .. -G "%CMAKE_GENERATOR%" -DCMAKE_PREFIX_PATH=%PREFIX% ^
+    -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX" ^
+    -DBOOST_ROOT=%LIBRARY% ^
+    -DWITH_BLOSC=ON ^
+    -DWITH_ZLIB=ON ^
+    -DWITH_BZIP2=OFF ^
+    -DWITH_XZ=OFF ^
+    -DPYTHON_EXECUTABLE=%PYTHON%
+
+
+cmake --build . --config %CONFIGURATION%
+REM xcopy ${SRC_DIR}/build/python/z5py %LIBRARY%/lib/python${PY_VER}/site-packages/ /E

--- a/z5/build.sh
+++ b/z5/build.sh
@@ -1,0 +1,65 @@
+# Platform-specific dylib extension
+if [ $(uname) == "Darwin" ]; then
+    export CC=clang
+    export CXX=clang++
+    export DYLIB="dylib"
+else
+    export CC=gcc
+    export CXX=g++
+    export DYLIB="so"
+fi
+
+##
+## START THE BUILD
+##
+
+mkdir -p build
+cd build
+
+CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include"
+LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib"
+
+if [ $(uname) == Darwin ]; then
+    CXXFLAGS="$CXXFLAGS -stdlib=libc++"
+fi
+
+# Set the correct python flags, depending on the distribution
+PY_VER=$(python -c "import sys; print('{}.{}'.format(*sys.version_info[:2]))")
+PY_ABIFLAGS=$(python -c "import sys; print('' if sys.version_info.major == 2 else sys.abiflags)")
+PY_ABI=${PY_VER}${PY_ABIFLAGS}
+
+##
+## Configure
+##
+cmake .. \
+        -DCMAKE_C_COMPILER=${CC} \
+        -DCMAKE_CXX_COMPILER=${CXX} \
+        -DCMAKE_BUILD_TYPE=RELEASE \
+        -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9\
+        -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+        -DCMAKE_PREFIX_PATH=${PREFIX} \
+\
+        -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS}" \
+        -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}" \
+        -DCMAKE_CXX_FLAGS="${CXXFLAGS} -O3 -DNDEBUG -std=c++17" \
+\
+        -DBOOST_ROOT=${PREFIX} \
+        -DWITH_BLOSC=ON \
+        -DWITH_ZLIB=ON \
+        -DWITH_BZIP2=ON \
+        -DWITH_XZ=ON \
+\
+        -DPYTHON_EXECUTABLE=${PYTHON} \
+        -DPYTHON_LIBRARY=${PREFIX}/lib/libpython${PY_ABI}.${DYLIB} \
+        -DPYTHON_INCLUDE_DIR=${PREFIX}/include/python${PY_ABI} \
+##
+
+##
+## Compile
+##
+make -j${CPU_COUNT}
+#make test
+
+##
+## Install to prefix
+cp -r ${SRC_DIR}/build/python/z5py ${PREFIX}/lib/python${PY_VER}/site-packages/

--- a/z5/conda_build_config.yaml
+++ b/z5/conda_build_config.yaml
@@ -1,0 +1,15 @@
+boost:
+  - 1.63.0
+numpy:
+  - 1.12
+python:
+  - 3.6
+xtensor:
+  - 0.18.1
+xtensor_python:
+  - 0.21
+
+pin_run_as_build:
+  boost-cpp: x.x
+  numpy: x.x
+  python: x.x

--- a/z5/meta.yaml
+++ b/z5/meta.yaml
@@ -10,31 +10,31 @@ package:
 
 
 source:
-  path: ..
+  git_url: https://github.com/constantinpape/z5
+  git_tag: HEAD
 
 
 build:
   number: 0
-  string: py{{py}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
-
+  string: np{{CONDA_NPY}}py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
 
 requirements:
   build:
-    - python {{PY_VER}}*
+    - python {{ python }}
     - cmake
-    - boost-cpp 1.68.0  # the boost version needs to be fixed, because we are linking against specific shared objects
-    - xtensor 0.18.1
-    - xtensor-python 0.21.0
-    - numpy >=1.15
+    - boost-cpp  {{ boost }}  # the boost version needs to be fixed, because we are linking against specific shared objects
+    - xtensor {{ xtensor }}
+    - xtensor-python {{ xtensor_python }}
+    - numpy {{ numpy }}
     - nlohmann_json
     - blosc
     - bzip2
     - xz
     - zlib
   run:
-    - python {{PY_VER}}*
-    - boost-cpp 1.68.0
-    - numpy >=1.15
+    - python
+    - boost-cpp
+    - numpy
     - six
     - blosc
     - bzip2

--- a/z5/meta.yaml
+++ b/z5/meta.yaml
@@ -1,0 +1,47 @@
+package:
+  name:
+    z5py
+  {% set tagged_version = GIT_DESCRIBE_TAG|replace("v","")|replace("-", ".") %}
+  {% if GIT_DESCRIBE_NUMBER|int != 0 %}
+    {% set tagged_version = tagged_version + '.post' + GIT_DESCRIBE_NUMBER %}
+  {% endif %}
+  version:
+   {{tagged_version}}
+
+
+source:
+  path: ..
+
+
+build:
+  number: 0
+  string: py{{py}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
+
+
+requirements:
+  build:
+    - python {{PY_VER}}*
+    - cmake
+    - boost-cpp 1.68.0  # the boost version needs to be fixed, because we are linking against specific shared objects
+    - xtensor 0.18.1
+    - xtensor-python 0.21.0
+    - numpy >=1.15
+    - nlohmann_json
+    - blosc
+    - bzip2
+    - xz
+    - zlib
+  run:
+    - python {{PY_VER}}*
+    - boost-cpp 1.68.0
+    - numpy >=1.15
+    - six
+    - blosc
+    - bzip2
+    - xz
+    - zlib
+
+
+test:
+  imports:
+    - z5py

--- a/z5/patches/xtensor-copysign.patch
+++ b/z5/patches/xtensor-copysign.patch
@@ -1,0 +1,13 @@
+--- ../../_h_env/Library/include/xtensor/xmath.hpp
++++ ../../_h_env/Library/include/xtensor/xmath.hpp	
+@@ -279,7 +279,9 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);
+         using std::arg;
+
+         using std::atan2;
+-        using std::copysign;
++        #if !defined(_MSC_VER)
++            using std::copysign;
++        #endif
+         using std::fdim;
+         using std::fmax;
+         using std::fmin;

--- a/z5/patches/xtensor-sizet.patch
+++ b/z5/patches/xtensor-sizet.patch
@@ -1,0 +1,19 @@
+--- ../../_h_env/Library/include/xtensor/xtensor_simd.hpp
++++ ../../_h_env/Library/include/xtensor/xtensor_simd.hpp	
+@@ -56,14 +56,14 @@ namespace xsimd
+         using type = T;
+         using bool_type = bool;
+         using batch_bool = bool;
+-        static constexpr size_t size = 1;
++        static constexpr std::size_t size = 1;
+     };
+ 
+     template <class T>
+     struct revert_simd_traits
+     {
+         using type = T;
+-        static constexpr size_t size = simd_traits<type>::size;
++        static constexpr std::size_t size = simd_traits<type>::size;
+     };
+ 
+     template <class T>


### PR DESCRIPTION
atm we need our own recipe of `z5py`, mostly because of the newer `boost` version that is used on `conda-forge`.