### PR TITLE
updated conda recipe to use nmake

### DIFF
--- a/vigra/bld.bat
+++ b/vigra/bld.bat
@@ -4,23 +4,42 @@ cd build
 set CONFIGURATION=Release
 set PATH=%PATH%;%LIBRARY_PREFIX%\bin
 
-cmake .. -G "%CMAKE_GENERATOR%" -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" -DCMAKE_CXX_FLAGS="-DH5_BUILT_AS_DYNAMIC_LIB /EHsc -DFFTW_DLL -DBOOST_ALL_NO_LIB" -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" -DWITH_LEMON=1 -DPYTHON_EXECUTABLE="%PYTHON%" -DBUILD_SHARED_LIBS=1
+cmake .. -G "NMake Makefiles" ^
+    -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
+    -DTEST_VIGRANUMPY=1 ^
+    -DAUTOEXEC_TESTS=0 ^
+    -DCMAKE_CXX_FLAGS="-DH5_BUILT_AS_DYNAMIC_LIB /EHsc -DFFTW_DLL -DBOOST_ALL_NO_LIB" ^
+    -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+    -DWITH_LEMON=1 ^
+    -DPYTHON_EXECUTABLE="%PYTHON%" ^
+    -DBUILD_SHARED_LIBS=1
 if errorlevel 1 exit 1
 
 REM BUILD
-cmake --build . --target ALL_BUILD --config %CONFIGURATION%
+nmake check
 if errorlevel 1 exit 1
 
 REM TEST
-cmake --build . --target test_impex --config %CONFIGURATION%
-if errorlevel 1 exit 1
-cmake --build . --target test_hdf5impex --config %CONFIGURATION%
-if errorlevel 1 exit 1
-cmake --build . --target test_fourier --config %CONFIGURATION%
-if errorlevel 1 exit 1
-cmake --build . --target vigranumpytest --config %CONFIGURATION%
+ctest -V
 if errorlevel 1 exit 1
 
-REM INSTALL
-cmake --build . --target INSTALL --config %CONFIGURATION%
+nmake check_python
 if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1
+
+rem REM TEST
+rem cmake --build . --target test_impex --config %CONFIGURATION%
+rem if errorlevel 1 exit 1
+rem cmake --build . --target test_hdf5impex --config %CONFIGURATION%
+rem if errorlevel 1 exit 1
+rem cmake --build . --target test_fourier --config %CONFIGURATION%
+rem if errorlevel 1 exit 1
+rem cmake --build . --target vigranumpytest --config %CONFIGURATION%
+rem if errorlevel 1 exit 1
+
+rem REM INSTALL
+rem cmake --build . --target INSTALL --config %CONFIGURATION%
+rem if errorlevel 1 exit 1

--- a/vigra/bld.bat
+++ b/vigra/bld.bat
@@ -29,17 +29,3 @@ if errorlevel 1 exit 1
 
 nmake install
 if errorlevel 1 exit 1
-
-rem REM TEST
-rem cmake --build . --target test_impex --config %CONFIGURATION%
-rem if errorlevel 1 exit 1
-rem cmake --build . --target test_hdf5impex --config %CONFIGURATION%
-rem if errorlevel 1 exit 1
-rem cmake --build . --target test_fourier --config %CONFIGURATION%
-rem if errorlevel 1 exit 1
-rem cmake --build . --target vigranumpytest --config %CONFIGURATION%
-rem if errorlevel 1 exit 1
-
-rem REM INSTALL
-rem cmake --build . --target INSTALL --config %CONFIGURATION%
-rem if errorlevel 1 exit 1

--- a/vigra/meta.yaml
+++ b/vigra/meta.yaml
@@ -15,11 +15,12 @@ package:
 source:
   git_url: https://github.com/ukoethe/vigra
   git_tag: HEAD
+  patches:
 
 build:
   features:
     - vc14 # [win]
-  number: 10
+  number: 11
   msvc_compiler: 14.0 # [win]
 
   #


### PR DESCRIPTION
Builds on the `vigra` main repo, as well as on the `vigra-feedstock` use `nmake` these days. Furthermore, not using `nmake` leads to failure. Therefore we should synchronize our recipe.