### PR TITLE
create-app [osx,linux], don't use default channels

### DIFF
--- a/create-tarball.sh
+++ b/create-tarball.sh
@@ -77,7 +77,7 @@ else
 fi
 
 echo "Creating new ilastik-release environment using ${EVERYTHING_PKG}"
-conda create -q -y -n ilastik-release ${EVERYTHING_PKG} "$@"
+conda create -q -y -n ilastik-release ${EVERYTHING_PKG} --override-channels "$@"
 
 if [[ $USE_GIT_LATEST == 1 ]]; then
     # Instead of keeping the version from binstar, get the git repo

--- a/osx-packages/create-osx-app.sh
+++ b/osx-packages/create-osx-app.sh
@@ -82,7 +82,7 @@ else
 fi
 
 echo "Creating new ilastik-release environment using ${EVERYTHING_PKG}"
-conda create -q -y -n ilastik-release ${EVERYTHING_PKG} py2app "$@"
+conda create -q -y -n ilastik-release ${EVERYTHING_PKG} py2app --override-channels "$@"
 
 ## Replace all @rpath references with @loader_path references,
 ## and delete the RPATHs (some of which are absolute instead of relative).


### PR DESCRIPTION
Don't let default channel packages leak into the release - they might not be compatible (using `cf201901)