### PR TITLE
Remove ilastik meta dep

### DIFF
--- a/ilastik-recipe-specs.yaml
+++ b/ilastik-recipe-specs.yaml
@@ -324,3 +324,9 @@ recipe-specs:
       build-on:
        - win
 
+    - name: ilastik-dependencies-binary
+      recipe-repo: https://github.com/ilastik/ilastik-conda-recipes
+      tag: master
+      recipe-subdir: recipes/ilastik-dependencies-binary
+      environment:
+        WITH_SOLVERS: 1

--- a/recipes/ilastik-dependencies-binary/meta.yaml
+++ b/recipes/ilastik-dependencies-binary/meta.yaml
@@ -1,0 +1,32 @@
+{% if not WITH_TIKTORCH is defined %}
+{% set WITH_TIKTORCH = 0 %}
+{% endif %}
+{% set WITH_TIKTORCH = WITH_TIKTORCH|int %}
+
+
+package:
+    {% set package_name = "ilastik-dependencies-binary" %}
+
+    {% if WITH_TIKTORCH %}
+      {% set package_name = package_name + "-tiktorch" %}
+    {% endif %}
+  name: {{ package_name }}
+  version: "0.1"
+
+build:
+  number: 1000
+
+requirements:
+  run:
+  {% if WITH_TIKTORCH %}
+    - ilastik-dependencies-tiktorch
+  {% else %}
+    - ilastik-dependencies
+  {% endif %}
+    - ilastik-meta
+    - ilastik-package  # [win]
+    - ilastik-exe  # [win]
+    - ilastik-launch  # [not win]
+
+about:
+  summary: "A meta-package bundling requirements for producing ilastik binaries"

--- a/recipes/ilastik-dependencies/meta.yaml
+++ b/recipes/ilastik-dependencies/meta.yaml
@@ -23,7 +23,7 @@ package:
     version: 1.3.3
 
 build:
-  number: 1003
+  number: 1004
   track_features:
     # on osx we need to make sure that we install the numpy versions with openblas instead of mkl to prevent clashes with cplex
     - blas_openblas #[osx] 
@@ -86,8 +86,6 @@ requirements:
     - marching_cubes
     - numpy-allocation-tracking
     - vigra                     {{ vigra }}
-    - ilastik-meta
-    - ilastik-launch                           # [not win]
 {% if WITH_TIKTORCH %}
     - tiktorch-client
 {% endif %}

--- a/recipes/ilastik-launch/meta.yaml
+++ b/recipes/ilastik-launch/meta.yaml
@@ -3,4 +3,8 @@ package:
   version: 0.1
 
 build:
-  number: 1000
+  number: 1001
+
+requirements:
+  run:
+    - ilastik-meta

--- a/recipes/windows-installer/ilastik-exe/meta.yaml
+++ b/recipes/windows-installer/ilastik-exe/meta.yaml
@@ -5,9 +5,11 @@ package:
 # source is in recipe dir
 
 build:
-  number: 1000
+  number: 1001
 
 requirements:
   build:
     - {{ compiler("cxx") }}
     - cmake
+  run:
+    - ilastik-package

--- a/recipes/windows-installer/ilastik-package/meta.yaml
+++ b/recipes/windows-installer/ilastik-package/meta.yaml
@@ -12,6 +12,7 @@ requirements:
   run:
     - git
     - ilastik-dependencies-no-solvers
+    - ilastik-meta
 
 about:
   summary: "A meta-package for creating installers."


### PR DESCRIPTION
Summary:
 * remove `ilastik-meta` dependency from `ilastik-dependencies`: this enables creation of valid ilastik development environments without jumping the hoops of force-removing anything and rendering the environments useless (not possible to install anything new with recent conda changes).
 * added another meta package for binary generation that should contain all necessary packages to run the scripts that create binaries.


related to: https://github.com/ilastik/ilastik-conda-recipes/pull/65

@m-novikov Sorry, I cannot wait for your PR that also removes `ilastik-meta`. I'm too annoyed atm of not being able to install stuff into my "broken" environment.