### PR TITLE
reflecting backwards-incompatible changes in z5py

### DIFF
--- a/ilastik-pins.yaml
+++ b/ilastik-pins.yaml
@@ -27,3 +27,5 @@ tifffile:
   - 0.4.post2
 vigra:
   - 1.11
+z5py:
+  - 1.5.1

--- a/recipes/ilastik-dependencies/meta.yaml
+++ b/recipes/ilastik-dependencies/meta.yaml
@@ -64,7 +64,7 @@ requirements:
     - scikit-learn              {{ sklearn }}*
     - setuptools                
     - matplotlib
-    - z5py
+    - z5py                      >={{ z5py }}
     - attrs
     
     # -----------------------------------------------------------------


### PR DESCRIPTION
need to make sure to use z5py >= 1.5.1

z5py returns relative, internal paths in `visiteditems` as opposed to full
paths including the root (pre 1.5.1 behavior).

see also: https://github.com/ilastik/lazyflow/pull/325