### PR TITLE
reflect removal of build tools

### DIFF
--- a/recipes/vigra/build.sh
+++ b/recipes/vigra/build.sh
@@ -50,11 +50,7 @@ cmake ..\
         ${EXTRA_CMAKE_ARGS} \
 
 # BUILD
-if [[ `uname` == 'Darwin' ]]; then
-    make -j${CPU_COUNT} 2> >(python "${RECIPE_DIR}"/../build-utils/filter-macos-linker-warnings.py)
-else
-    make -j${CPU_COUNT}
-fi
+make -j${CPU_COUNT}
 
 # TEST (before install)
 (
@@ -74,7 +70,7 @@ fi
             # Can't run tests due to a bug in the clang compiler provided with XCode.
             # For more details see here ( https://llvm.org/bugs/show_bug.cgi?id=21083 ).
             # Also, these tests are very intensive, which makes them challenging to run in CI.
-            make -j${CPU_COUNT} check_python 2> >(python "${RECIPE_DIR}"/../build-utils/filter-macos-linker-warnings.py)
+            make -j${CPU_COUNT} check_python
         else
             make -j${CPU_COUNT} check
             make -j${CPU_COUNT} ctest


### PR DESCRIPTION
we used to filter the output of the mac build through a custom python script, which was designed for compilation with GCC. We're using clang now, removing