### PR TITLE
explicitly point to lemon library

### DIFF
--- a/recipes/vigra/bld.bat
+++ b/recipes/vigra/bld.bat
@@ -13,7 +13,8 @@ cmake .. -G "NMake Makefiles" ^
     -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
     -DWITH_LEMON=1 ^
     -DPYTHON_EXECUTABLE="%PYTHON%" ^
-    -DBUILD_SHARED_LIBS=1
+    -DBUILD_SHARED_LIBS=1 ^
+    -DLEMON_LIBRARY=%PREFIX%/Library/lib/lemon.lib
 
 if errorlevel 1 exit 1
 


### PR DESCRIPTION
vigra picked up some rogue lemon library during the build.
Explicitly specifying it resolved the problem.