### PR TITLE
include conda-meta in windows distribution

### DIFF
--- a/recipes/windows-installer/ilastik-package/ilastik.iss.in
+++ b/recipes/windows-installer/ilastik-package/ilastik.iss.in
@@ -34,6 +34,7 @@ Source: "Library\bin\qt.conf"; DestDir: "{app}\Library\bin"; Flags: ignoreversio
 Source: "Lib\*"; Excludes: "\plat-*,\test\*,\site-packages\matplotlib\tests\*"; DestDir: "{app}\Lib"; Flags: ignoreversion recursesubdirs
 Source: "Library\plugins\*"; DestDir: "{app}\Library\plugins"; Flags: ignoreversion recursesubdirs
 Source: "Scripts\*"; DestDir: "{app}\Scripts"; Flags: ignoreversion recursesubdirs
+Source: "conda-meta\*"; DestDir: "{app}\conda-meta"; Flags: ignoreversion recursesubdirs
 ; the grpc library relies on Library\mingw-w64
 Source: "Library\mingw-w64\*"; DestDir: "{app}\Library\mingw-w64"; Flags: ignoreversion recursesubdirs
 


### PR DESCRIPTION
we include conda-meta in the osx and linux distributions, which os nice in order to reproduce the release environments. This patch adds this to the windows installer, too.