### PR TITLE
Update cycle 1.4

### DIFF
--- a/ilastik-pins.yaml
+++ b/ilastik-pins.yaml
@@ -30,6 +30,9 @@ tifffile:
 # make sure to use a vigra build that includes lemon!
 vigra:
   - 1.11.1 py37ha1f80a5_1017  # [linux]
+  - 1.11.1 py37h05204d7_1017  # [osx]
+# still on own build where the correct channel priority guarantees version on win
+  - 1.11.1  # [win]
 z5py:
   - 2
 

--- a/ilastik-pins.yaml
+++ b/ilastik-pins.yaml
@@ -3,10 +3,6 @@ CONDA_BUILD_SYSROOT:
 
 boost:
   - 1.72.0
-# this is an unfortunate one
-# see https://github.com/ilastik/ilastik-conda-recipes/issues/83
-gdkpixbuf:
-  - 2.36.12 h7a26e22_1003
 h5py:
   - 2.10.0
 hdf5:

--- a/ilastik-pins.yaml
+++ b/ilastik-pins.yaml
@@ -2,7 +2,7 @@ CONDA_BUILD_SYSROOT:
   - /Developer/SDKs/MacOSX10.9.sdk  # [osx]
 
 boost:
-  - 1.70.0
+  - 1.72.0
 # this is an unfortunate one
 # see https://github.com/ilastik/ilastik-conda-recipes/issues/83
 gdkpixbuf:
@@ -10,7 +10,7 @@ gdkpixbuf:
 h5py:
   - 2.10.0
 hdf5:
-  - 1.10.5
+  - 1.10.6
 jpeg:
   - 9
 lemon:
@@ -27,14 +27,13 @@ pandas:
   - 0.24
 python:
   - 3.7
-pyqt:
-  - 5.6
 qt:
-  - 5.6
+  - 5.12
 tifffile:
   - 0.4.post2
+# make sure to use a vigra build that includes lemon!
 vigra:
-  - 1.11
+  - 1.11.1 py37ha1f80a5_1017  # [linux]
 z5py:
   - 2
 

--- a/ilastik-recipe-specs.yaml
+++ b/ilastik-recipe-specs.yaml
@@ -2,10 +2,10 @@ shared-config:
     master-conda-build-config: ./ilastik-pins.yaml
     repo-cache-dir: ./repo-cache # Relative to this yaml file's directory.
     source-channels:
-        - ilastik-forge/label/ilastik14
-        - ilastik-forge/label/novigra
+        - ilastik-forge/label/ilastik140
         - conda-forge
-    destination-channel: ilastik-forge/label/ilastik14
+        - defaults
+    destination-channel: ilastik-forge/label/ilastik140
 
 # Some notes on the used environment variables:
 #   with packages build by conda-forge, which, presumably, used gcc 4.8.5.
@@ -143,7 +143,7 @@ recipe-specs:
 
     - name: ilastik-dependencies-no-solvers
       recipe-repo: https://github.com/ilastik/ilastik-conda-recipes
-      tag: master
+      tag: update-cycle-1.4
       recipe-subdir: recipes/ilastik-dependencies
       environment:
         WITH_SOLVERS: 0

--- a/ilastik-recipe-specs.yaml
+++ b/ilastik-recipe-specs.yaml
@@ -185,7 +185,7 @@ recipe-specs:
       tag: master
       recipe-subdir: recipes/cplex-shared
       environment:
-        CPLEX_ROOT_DIR: /build/in/gurobi811/linux64
+        CPLEX_ROOT_DIR: /opt/gurobi903/linux64
 
     - name: cplex-shared
       build-on:
@@ -210,7 +210,7 @@ recipe-specs:
       tag: master
       recipe-subdir: recipes/gurobi-symlink
       environment:
-        GUROBI_ROOT_DIR: /build/in/gurobi811/linux64
+        GUROBI_ROOT_DIR: /opt/gurobi903/linux64
 
     - name: gurobi-symlink
       build-on:
@@ -219,7 +219,7 @@ recipe-specs:
       tag: master
       recipe-subdir: recipes/gurobi-symlink
       environment:
-        GUROBI_ROOT_DIR: /Library/gurobi811/mac64
+        GUROBI_ROOT_DIR: /Library/gurobi903/mac64
 
     - name: gurobi-symlink
       build-on:
@@ -228,7 +228,7 @@ recipe-specs:
       tag: master
       recipe-subdir: recipes/gurobi-symlink
       environment:
-        GUROBI_ROOT_DIR: /gurobi811/win64
+        GUROBI_ROOT_DIR: /gurobi903/win64
 
     - name: multi-hypotheses-tracking-with-gurobi
       build-on:
@@ -240,7 +240,7 @@ recipe-specs:
       environment:
         WITH_CPLEX: 0
         WITH_GUROBI: 1
-        GUROBI_ROOT_DIR: /opt/gurobi811/linux64
+        GUROBI_ROOT_DIR: /opt/gurobi903/linux64
 
     - name: multi-hypotheses-tracking-with-gurobi
       build-on:
@@ -252,7 +252,7 @@ recipe-specs:
       environment:
         WITH_CPLEX: 0
         WITH_GUROBI: 1
-        GUROBI_ROOT_DIR: /Library/gurobi811/mac64
+        GUROBI_ROOT_DIR: /Library/gurobi903/mac64
 
     - name: multi-hypotheses-tracking-with-gurobi
       build-on:
@@ -264,8 +264,8 @@ recipe-specs:
       environment:
         WITH_CPLEX: 0
         WITH_GUROBI: 1
-        GUROBI_ROOT_DIR: /gurobi811/win64
-        GUROBI_LIB_WIN: /gurobi811/win64/lib/gurobi81.lib
+        GUROBI_ROOT_DIR: /gurobi903/win64
+        GUROBI_LIB_WIN: /gurobi903/win64/lib/gurobi90.lib
 
     - name: multi-hypotheses-tracking-with-cplex
       build-on:
@@ -276,7 +276,7 @@ recipe-specs:
       environment:
         WITH_CPLEX: 1
         WITH_GUROBI: 0
-        CPLEX_ROOT_DIR: /build/in/cplex
+        CPLEX_ROOT_DIR: /opt/cplex
 
     - name: multi-hypotheses-tracking-with-cplex
       build-on:

--- a/ilastik-recipe-specs.yaml
+++ b/ilastik-recipe-specs.yaml
@@ -2,10 +2,10 @@ shared-config:
     master-conda-build-config: ./ilastik-pins.yaml
     repo-cache-dir: ./repo-cache # Relative to this yaml file's directory.
     source-channels:
-        - ilastik-forge/label/staging
-        - ilastik-forge
+        - ilastik-forge/label/ilastik14
+        - ilastik-forge/label/novigra
         - conda-forge
-    destination-channel: ilastik-forge
+    destination-channel: ilastik-forge/label/ilastik14
 
 # Some notes on the used environment variables:
 #   with packages build by conda-forge, which, presumably, used gcc 4.8.5.
@@ -23,16 +23,17 @@ recipe-specs:
     ## from the beginning of the list, but not vice-versa.
     ##
 
-    - name: lemon
-      recipe-repo: https://github.com/ilastik/ilastik-conda-recipes
-      tag: master
-      recipe-subdir: recipes/lemon
-      # conda-build-flags: --no-test
-      # by default a package is built on all 3 platforms
-      build-on:
-        - linux
-        - win
-        - osx
+    # using conda forge build
+    # - name: lemon
+    #   recipe-repo: https://github.com/ilastik/ilastik-conda-recipes
+    #   tag: master
+    #   recipe-subdir: recipes/lemon
+    #   # conda-build-flags: --no-test
+    #   # by default a package is built on all 3 platforms
+    #   build-on:
+    #     - linux
+    #     - win
+    #     - osx
 
     # FIXME: We temporarily build our own windows hdf5 package, because of
     # insufficient unicode support of release version 1.10.1.
@@ -43,20 +44,22 @@ recipe-specs:
       # tag: utf-8-support
       # recipe-subdir: recipe
 
-    - name: z5py
-      recipe-repo: https://github.com/k-dominik/z5py-feedstock
-      tag: ilastik-bld
-      recipe-subdir: recipe
+    # using conda-forge build
+    # - name: z5py
+    #   recipe-repo: https://github.com/k-dominik/z5py-feedstock
+    #   tag: ilastik-bld
+    #   recipe-subdir: recipe
 
-    # FIXME: We would like to use conda-forge's package for vigra,
-    # but it doesn't build WITH_LEMON yet.
-    - name: vigra
-      recipe-repo: https://github.com/ilastik/ilastik-conda-recipes
-      tag: master
-      recipe-subdir: recipes/vigra
-      environment:
-        VIGRA_SKIP_TESTS: 0
-      no-test: false
+    # using conda-forge build
+    # # FIXME: We would like to use conda-forge's package for vigra,
+    # # but it doesn't build WITH_LEMON yet.
+    # - name: vigra
+    #   recipe-repo: https://github.com/ilastik/ilastik-conda-recipes
+    #   tag: master
+    #   recipe-subdir: recipes/vigra
+    #   environment:
+    #     VIGRA_SKIP_TESTS: 0
+    #   no-test: false
 
     - name: dpct
       recipe-repo: https://github.com/ilastik/dpct

--- a/recipes/ilastik-dependencies/meta.yaml
+++ b/recipes/ilastik-dependencies/meta.yaml
@@ -12,7 +12,7 @@ package:
     {% endif %}
 
     name: {{ package_name }}
-    version: 1.4.0
+    version: 1.4.1
 
 build:
   number: 5
@@ -28,8 +28,7 @@ requirements:
     # -----------------------------------------------------------------
     # General dependencies
     # -----------------------------------------------------------------
-    - python                    {{ python }}  # [not osx]
-    - python                    3.7.3         # [osx]
+    - python
     - numpy                     {{ numpy }}
 
     - appdirs
@@ -49,19 +48,20 @@ requirements:
     - pillow                    {{ pillow }}
     - psutil
     - pyopengl
-    - pyqt                      {{ pyqt }}
+    - pyqt
     - pyqtgraph
-    - pytest                    {{ pytest }}
+    - pytest                    {{ pytest }}*
     - pytest-qt
     - python-dateutil
     - pytz
     - qimage2ndarray
-    - qt                        {{ qt }}
+    - qt                        {{ qt }}*
     - readline                                 # [not win]
     - requests
     - scikit-image
     - scikit-learn              {{ sklearn }}*
     - setuptools
+    - vigra                     {{ vigra }}
     - yapsy
     - z5py                      >={{ z5py }}
 

--- a/recipes/ilastik-dependencies/meta.yaml
+++ b/recipes/ilastik-dependencies/meta.yaml
@@ -37,7 +37,6 @@ requirements:
     - decorator
     - fftw
     - future
-    - gdk-pixbuf                {{ gdkpixbuf }}  # [linux]
     - greenlet
     - h5py                      {{ h5py }}
     - hdf5                      {{ hdf5 }}

--- a/recipes/ilastik-dependencies/meta.yaml
+++ b/recipes/ilastik-dependencies/meta.yaml
@@ -19,7 +19,7 @@ build:
 
   track_features:
     # on osx we need to make sure that we install the numpy versions with openblas instead of mkl to prevent clashes with cplex
-    - blas_openblas #[osx]
+    - blas_openblas  # [osx]
 #
 # In general, we don't specify exact version requirements in each sub-package.
 # But this file tracks the versions of all packages used in the release.


### PR DESCRIPTION
updates for ilastik1.4

major differences:

* `vigra` sources from conda-forge (except windows, waiting for https://github.com/conda-forge/vigra-feedstock/pull/65 and https://github.com/conda-forge/lemon-feedstock/pull/18)
* `qt: 5.6 -> 5.12`
* `boost: 1.70 -> 1.72`
* `hdf5: 1.10.5 -> 1.10.6` (