### PR TITLE
Add xarray to ilastik-dependencies

### DIFF
--- a/recipes/ilastik-dependencies/meta.yaml
+++ b/recipes/ilastik-dependencies/meta.yaml
@@ -12,10 +12,10 @@ package:
     {% endif %}
 
     name: {{ package_name }}
-    version: 1.4.1
+    version: 1.4.2
 
 build:
-  number: 5
+  number: 0
 
   track_features:
     # on osx we need to make sure that we install the numpy versions with openblas instead of mkl to prevent clashes with cplex
@@ -61,6 +61,7 @@ requirements:
     - scikit-learn              {{ sklearn }}*
     - setuptools
     - vigra                     {{ vigra }}
+    - xarray
     - yapsy
     - z5py                      >={{ z5py }}
 


### PR DESCRIPTION
bumped  `ilastik-dependencies` version to `1.4.2`. Results in `xarray 0.14.1` on all three platforms. Not the latest version because of our pandas pin.

Todo:

* [x] check linux
* [x] check win
* [x] check osx