### PR TITLE
strip some paths before packaging

### DIFF
--- a/ilastik-pins.yaml
+++ b/ilastik-pins.yaml
@@ -38,7 +38,7 @@ vigra:
 z5py:
   - 2
 tiktorch:
-  - 21.10.1
+  - 21.10.2
 
 
 pin_run_as_build:

--- a/packaging/linux/create-tarball.sh
+++ b/packaging/linux/create-tarball.sh
@@ -38,21 +38,13 @@ rm -f ${CONDA_ROOT}/envs/ilastik-release/lib/libconcert.so
 # Remove gurobi symlinks (if present)
 rm -f ${RELEASE_ENV}/lib/libgurobi*.so
 
-if [[ $INCLUDE_TESTS == 1 ]]; then
-    echo "Including ilastik tests in release (larger release size)."
-else
-    echo "Removing ilastik tests from source folders"
-    ILASTIK_META=${CONDA_ROOT}/envs/ilastik-release/ilastik-meta
-    rm -rf ${ILASTIK_META}/*/tests/*
-    echo "test-files removed"
-fi
-
-
 # Create the tarball, and move it to the current directory.
 echo "Creating ${RELEASE_NAME}.tar.bz2"
 cd ${CONDA_ROOT}/envs/
 mv ilastik-release ${RELEASE_NAME}
 tar -cjf ${RELEASE_NAME}.tar.bz2 ${RELEASE_NAME}
+echo "Cleaning up... "
+rm -rf ${RELEASE_NAME}
 if [[ !(${OUTPUT_PATH} -ef ${PWD}) ]];
 then
     echo "Moving release to ${OUTPUT_PATH}"

--- a/packaging/make-release.py
+++ b/packaging/make-release.py
@@ -46,7 +46,10 @@ DEFAULT_CHANNELS = ["ilastik-forge", "pytorch", "conda-forge"]
 
 
 STRIP_PATHS = {
-    "common": [Path("include"), Path("ilastik-meta/ilastik/tests"), Path("qml"), Path("share/doc")]
+    "common": [Path("ilastik-meta/ilastik/tests")],
+    "linux": [Path("include"), Path("qml"), Path("share/doc")],
+    "darwin": [Path("include"), Path("qml"), Path("share/doc")],
+    "windows": [],  # stripping on windows via installer builder
 }
 
 ISS = None
@@ -87,7 +90,7 @@ class CondaEnv:
 
     def _strip(self):
         logger.info("Stripping release")
-        for p in STRIP_PATHS["common"]:
+        for p in STRIP_PATHS["common"] + STRIP_PATHS[OS]:
             try:
                 current = self.path / p
                 logger.info(f"removing {current}")

--- a/packaging/make-release.py
+++ b/packaging/make-release.py
@@ -31,7 +31,7 @@ ILASTIK_PACKAGES = {
     },
     "gpu": {
         "linux": ["cudatoolkit>=11.0"],
-        "windows": ["cudatoolkit>=11.0"],
+        "windows": ["cudatoolkit=11.0"],
     },
 }
 
@@ -178,7 +178,7 @@ class IlastikRelease:
         iss_in = self._release_env.path / "package" / "ilastik.iss.in"
         iss_out = iss_in.parent / "ilastik.iss"
 
-        iss_out.write_text(re.sub("@VERSION@", self._imeta_version, iss_in.read_text()))
+        iss_out.write_text(re.sub("@VERSION@", f"{self._imeta_version}{self._release_variant_suffix}", iss_in.read_text()))
 
     def _prepare_darwin(self) -> None:
         pass

--- a/recipes/ilastik-dependencies/conda_build_config.yaml
+++ b/recipes/ilastik-dependencies/conda_build_config.yaml
@@ -1,5 +1,5 @@
 bioimageiospec:
-  - 0.3.3.post1
+  - 0.3.3.post2
 bioimageiocore:
   - 0.4.0
 h5py:
@@ -28,7 +28,7 @@ pytest:
 pillow:
   - 5.3.0
 tiktorch:
-  - 21.9.1
+  - 21.10.2
 
 pin_run_as_build:
   h5py: x.x

--- a/recipes/ilastik-dependencies/meta.yaml
+++ b/recipes/ilastik-dependencies/meta.yaml
@@ -14,7 +14,7 @@ package:
     version: 1.4.5
 
 build:
-  number: 0
+  number: 1
 
 
   track_features:


### PR DESCRIPTION
removes some files before packaging (full tiktorch cuda dist)*.

| os  | archive size | stripped archive size |
| --- | --- | ---|
| osx | 686 MB | 420 MB |
| linux | 2.5 GB| 2.3 GB |
| windows | 1.8 GB | win already stripped down |

----------

\* no cuda on osx


---------


#### Top10 linux files (uncompressed):

```
1,1G	ilastik-1.4.0b17-Linux/lib/python3.7/site-packages/torch/lib/libtorch_cuda.so
517M	ilastik-1.4.0b17-Linux/lib/libcusolver.so.10.6.0.245
313M	ilastik-1.4.0b17-Linux/lib/libcusolverMg.so.10.6.0.245
168M	ilastik-1.4.0b17-Linux/lib/libcublasLt.so.11.2.0.252
157M	ilastik-1.4.0b17-Linux/lib/libcufft.so.10.2.1.245
154M	ilastik-1.4.0b17-Linux/lib/libcusparse.so.11.1.1.245
132M	ilastik-1.4.0b17-Linux/lib/python3.7/site-packages/torch/lib/libtorch_cpu.so
102M	ilastik-1.4.0b17-Linux/lib/libLLVM-11.so
93M	ilastik-1.4.0b17-Linux/lib/libcublas.so.11.2.0.252
92M	ilastik-1.4.0b17-Linux/lib/libLLVM-10.so
```