### PR TITLE
added pytorch-cpu version helper

### DIFF
--- a/ilastik-recipe-specs.yaml
+++ b/ilastik-recipe-specs.yaml
@@ -114,6 +114,11 @@ recipe-specs:
       build-on:
         - osx
 
+    - name: ilastik-pytorch-version-helper-cpu
+      recipe-repo: https://github.com/ilastik/ilastik-conda-recipes
+      tag: main
+      recipe-subdir: recipes/ilastik-pytorch-version-helper-cpu
+
 ############################################################################
 ##
 ## All the following packages need solvers, or are only needed if solvers are present

--- a/recipes/ilastik-pytorch-version-helper-cpu/meta.yaml
+++ b/recipes/ilastik-pytorch-version-helper-cpu/meta.yaml
@@ -1,0 +1,22 @@
+# This is necessary in order to properly solve ilastik environments with
+# pytorch <1.10 with both, conda and mamba.
+# mamba doesn't respect track features, which pytorch relies on (until 1.9).
+# without track features, mamba prioritizes gpu builds even with cpuonly present
+# note: pytorch 1.10 relies on mutex package, but doesn't properly resolve.
+
+# this little helper recipe allows for the ilastik-x recipes to remain noarch
+# while this one isn't.
+
+package:
+  name: "ilastik-pytorch-version-helper-cpu"
+  version: "0.1"
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - pytorch =*=*cpu*  # [not osx]
+
+about:
+  summary: "small helper package to allow for consistent solving of cpu pytorch environments"


### PR DESCRIPTION
we are in the process of switching to mamba. There turned out to be some subtle quirks. In particular, mamba doesn't respect `track_features` and ends up solving pytorch environments not correctly. The `ilastik-pytorch-version-helper-cpu` is a small package that I added in order to keep the ilastik recipes noarch. For cpu variants on linux/windows it will require pytorch builds that end on `*cpu` - such a limitation is not necessary on osx (currently there is a cpu version only - that doesn't have a cpu postfix).

* `mamba 0.19.1`
* `conda 4.11.0`


example env with mamba without the package (`mamba create -n blah -c pytorch -c ilastik-forge -c conda-forge pytorch=1.9 cpuonly`):

<details>

```
  + _libgcc_mutex            0.1  conda_forge                  conda-forge/linux-64
  + _openmp_mutex            4.5  1_llvm                       conda-forge/linux-64
  + blas                   2.113  mkl                          conda-forge/linux-64
  + blas-devel             3.9.0  13_linux64_mkl               conda-forge/linux-64
  + bzip2                  1.0.8  h7f98852_4                   conda-forge/linux-64
  + ca-certificates    2021.10.8  ha878542_0                   conda-forge/linux-64
  + cpuonly                  2.0  0                            pytorch/noarch      
  + cudatoolkit           11.1.1  h6406543_10                  conda-forge/linux-64
  + ld_impl_linux-64      2.36.1  hea4e1c9_2                   conda-forge/linux-64
  + libblas                3.9.0  13_linux64_mkl               conda-forge/linux-64
  + libcblas               3.9.0  13_linux64_mkl               conda-forge/linux-64
  + libffi                 3.4.2  h7f98852_5                   conda-forge/linux-64
  + libgcc-ng             11.2.0  h1d223b6_12                  conda-forge/linux-64
  + libgfortran-ng        11.2.0  h69a702a_12                  conda-forge/linux-64
  + libgfortran5          11.2.0  h5c6108e_12                  conda-forge/linux-64
  + liblapack              3.9.0  13_linux64_mkl               conda-forge/linux-64
  + liblapacke             3.9.0  13_linux64_mkl               conda-forge/linux-64
  + libnsl                 2.0.0  h7f98852_0                   conda-forge/linux-64
  + libstdcxx-ng          11.2.0  he4da1e4_12                  conda-forge/linux-64
  + libuuid               2.32.1  h7f98852_1000                conda-forge/linux-64
  + libuv                 1.43.0  h7f98852_0                   conda-forge/linux-64
  + libzlib               1.2.11  h36c2ea0_1013                conda-forge/linux-64
  + llvm-openmp           13.0.1  hf817b99_0                   conda-forge/linux-64
  + mkl                 2022.0.1  h8d4b97c_803                 conda-forge/linux-64
  + mkl-devel           2022.0.1  ha770c72_804                 conda-forge/linux-64
  + mkl-include         2022.0.1  h8d4b97c_803                 conda-forge/linux-64
  + ncurses                  6.3  h9c3ff4c_0                   conda-forge/linux-64
  + ninja                 1.10.2  h4bd325d_1                   conda-forge/linux-64
  + openssl                3.0.0  h7f98852_2                   conda-forge/linux-64
  + pip                   22.0.3  pyhd8ed1ab_0                 conda-forge/noarch  
  + python                3.9.10  hc74c709_2_cpython           conda-forge/linux-64
  + python_abi               3.9  2_cp39                       conda-forge/linux-64
  + pytorch                1.9.1  py3.9_cuda11.1_cudnn8.0.5_0  pytorch/linux-64    
  + pytorch-mutex            1.0  cpu                          pytorch/noarch      
  + readline                 8.1  h46c0cb4_0                   conda-forge/linux-64
  + setuptools            60.9.1  py39hf3d152e_0               conda-forge/linux-64
  + sqlite                3.37.0  h9cd32fc_0                   conda-forge/linux-64
  + tbb                 2021.5.0  h4bd325d_0                   conda-forge/linux-64
  + tk                    8.6.11  h27826a3_1                   conda-forge/linux-64
  + typing_extensions      4.1.1  pyha770c72_0                 conda-forge/noarch  
  + tzdata                 2021e  he74cb21_0                   conda-forge/noarch  
  + wheel                 0.37.1  pyhd8ed1ab_0                 conda-forge/noarch  
  + xz                     5.2.5  h516909a_1                   conda-forge/linux-64
  + zlib                  1.2.11  h36c2ea0_1013                conda-forge/linux-64
```

</details>

example env with mamba with thispackage (`mamba create -n blah -c pytorch -c ilastik-forge -c conda-forge pytorch=1.9 cpuonly ilastik-pytorch-version-helper-cpu`):

<details>

```
  + _libgcc_mutex                             0.1  conda_forge         conda-forge/linux-64
  + _openmp_mutex                             4.5  1_llvm              conda-forge/linux-64
  + blas                                    2.113  mkl                 conda-forge/linux-64
  + blas-devel                              3.9.0  13_linux64_mkl      conda-forge/linux-64
  + bzip2                                   1.0.8  h7f98852_4          conda-forge/linux-64
  + ca-certificates                     2021.10.8  ha878542_0          conda-forge/linux-64
  + cpuonly                                   2.0  0                   pytorch/noarch      
  + ilastik-pytorch-version-helper-cpu        0.1  0                   ilastik-forge/linux-64
  + ld_impl_linux-64                       2.36.1  hea4e1c9_2          conda-forge/linux-64
  + libblas                                 3.9.0  13_linux64_mkl      conda-forge/linux-64
  + libcblas                                3.9.0  13_linux64_mkl      conda-forge/linux-64
  + libffi                                  3.4.2  h7f98852_5          conda-forge/linux-64
  + libgcc-ng                              11.2.0  h1d223b6_12         conda-forge/linux-64
  + libgfortran-ng                         11.2.0  h69a702a_12         conda-forge/linux-64
  + libgfortran5                           11.2.0  h5c6108e_12         conda-forge/linux-64
  + liblapack                               3.9.0  13_linux64_mkl      conda-forge/linux-64
  + liblapacke                              3.9.0  13_linux64_mkl      conda-forge/linux-64
  + libnsl                                  2.0.0  h7f98852_0          conda-forge/linux-64
  + libstdcxx-ng                           11.2.0  he4da1e4_12         conda-forge/linux-64
  + libuuid                                2.32.1  h7f98852_1000       conda-forge/linux-64
  + libuv                                  1.43.0  h7f98852_0          conda-forge/linux-64
  + libzlib                                1.2.11  h36c2ea0_1013       conda-forge/linux-64
  + llvm-openmp                            13.0.1  hf817b99_0          conda-forge/linux-64
  + mkl                                  2022.0.1  h8d4b97c_803        conda-forge/linux-64
  + mkl-devel                            2022.0.1  ha770c72_804        conda-forge/linux-64
  + mkl-include                          2022.0.1  h8d4b97c_803        conda-forge/linux-64
  + ncurses                                   6.3  h9c3ff4c_0          conda-forge/linux-64
  + ninja                                  1.10.2  h4bd325d_1          conda-forge/linux-64
  + openssl                                 3.0.0  h7f98852_2          conda-forge/linux-64
  + pip                                    22.0.3  pyhd8ed1ab_0        conda-forge/noarch  
  + python                                 3.9.10  hc74c709_2_cpython  conda-forge/linux-64
  + python_abi                                3.9  2_cp39              conda-forge/linux-64
  + pytorch                                 1.9.1  py3.9_cpu_0         pytorch/linux-64    
  + pytorch-mutex                             1.0  cpu                 pytorch/noarch      
  + readline                                  8.1  h46c0cb4_0          conda-forge/linux-64
  + setuptools                             60.9.1  py39hf3d152e_0      conda-forge/linux-64
  + sqlite                                 3.37.0  h9cd32fc_0          conda-forge/linux-64
  + tbb                                  2021.5.0  h4bd325d_0          conda-forge/linux-64
  + tk                                     8.6.11  h27826a3_1          conda-forge/linux-64
  + typing_extensions                       4.1.1  pyha770c72_0        conda-forge/noarch  
  + tzdata                                  2021e  he74cb21_0          conda-forge/noarch  
  + wheel                                  0.37.1  pyhd8ed1ab_0        conda-forge/noarch  
  + xz                                      5.2.5  h516909a_1          conda-forge/linux-64
  + zlib                                   1.2.11  h36c2ea0_1013       conda-forge/linux-64
```
</details>


note: conda solves the env correctly without the additional package...