### PR TITLE
change requirements for ilastik-launch

### DIFF
--- a/recipes/ilastik-launch/README.md
+++ b/recipes/ilastik-launch/README.md
@@ -1,0 +1,8 @@
+# ilastik-launch
+
+This allows to get a binary: `${CONDA_PREFIX}/run_ilastik.sh`
+
+To install it requires channels:
+- ilastik-forge
+- pytorch
+- conda-forge

--- a/recipes/ilastik-launch/README.md
+++ b/recipes/ilastik-launch/README.md
@@ -1,6 +1,9 @@
 # ilastik-launch
 
-This allows to get a binary: `${CONDA_PREFIX}/run_ilastik.sh`
+
+
+This allows to get a binary: `${CONDA_PREFIX}/run_ilastik.sh`.
+Intended to be used only in the ilastik binary distribution on Linux/OSX.
 
 To install it requires channels:
 - ilastik-forge

--- a/recipes/ilastik-launch/meta.yaml
+++ b/recipes/ilastik-launch/meta.yaml
@@ -7,4 +7,4 @@ build:
 
 requirements:
   run:
-    - ilastik
+    - ilastik >=1.4.0b29

--- a/recipes/ilastik-launch/meta.yaml
+++ b/recipes/ilastik-launch/meta.yaml
@@ -3,9 +3,8 @@ package:
   version: 0.3
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:
-    - ilastik-core
-    - volumina
+    - ilastik

--- a/recipes/ilastik-launch/run_ilastik.sh
+++ b/recipes/ilastik-launch/run_ilastik.sh
@@ -65,4 +65,4 @@ export FONTCONFIG_PATH="${PREFIX}/etc/fonts/"
 export FONTCONFIG_FILE="${PREFIX}/etc/fonts/fonts.conf"
 
 # Launch the ilastik entry script, and pass along any commmand line args.
-"${PREFIX}/bin/python" "${PREFIX}/bin/ilastik-app" "$@"
+"${PREFIX}/bin/python" "${PREFIX}/bin/ilastik" "$@"


### PR DESCRIPTION
Hi,
I tried to install through conda ilastik-launch and I got an error as `${PREFIX}/bin/ilastik-app` does not exists.
This binary only exists if you install ilastik, therefore, I think it should be a requirement.
Regards,
Lucille