### PR TITLE
add package fiji-ilastik-helper

### DIFF
--- a/recipes/fiji-ilastik-helper/ImageJ_withIlastik.py
+++ b/recipes/fiji-ilastik-helper/ImageJ_withIlastik.py
@@ -1,0 +1,15 @@
+import subprocess
+import sys
+from pathlib import Path
+import os
+
+
+def main():
+    java_file = Path(__file__).parent / "IlastikSetter.java"
+    ilastik_exe = Path(os.getenv("CONDA_PREFIX")) / "bin" / "ilastik"
+    subprocess.check_call(["java", str(java_file), str(ilastik_exe)])
+    subprocess.run(["ImageJ"] + sys.argv[1::])
+
+
+if __name__ == '__main__':
+    main()

--- a/recipes/fiji-ilastik-helper/ImageJ_withIlastik/IlastikSetter.java
+++ b/recipes/fiji-ilastik-helper/ImageJ_withIlastik/IlastikSetter.java
@@ -1,0 +1,8 @@
+import java.util.prefs.Preferences;
+
+public class IlastikSetter {
+	public static void main(String... args) {
+		Preferences prefs = Preferences.userRoot().node("org/ilastik/ilastik4ij/ui/IlastikOptions");
+		prefs.put("executableFile", args[0]);
+	}
+}

--- a/recipes/fiji-ilastik-helper/ImageJ_withIlastik/__init__.py
+++ b/recipes/fiji-ilastik-helper/ImageJ_withIlastik/__init__.py
@@ -1,0 +1,20 @@
+import subprocess
+import sys
+from pathlib import Path
+import os
+import platform
+
+
+def main():
+    java_file = Path(__file__).parent / "IlastikSetter.java"
+    if platform.system() == "Windows":
+        ilastik_exe = Path(os.getenv("CONDA_PREFIX")) / "Scripts" / "ilastik.exe"
+    else:
+        ilastik_exe = Path(os.getenv("CONDA_PREFIX")) / "bin" / "ilastik"
+
+    subprocess.check_call(["java", str(java_file), str(ilastik_exe)])
+    subprocess.run(["ImageJ"] + sys.argv[1::])
+
+
+if __name__ == '__main__':
+    main()

--- a/recipes/fiji-ilastik-helper/MANIFEST.in
+++ b/recipes/fiji-ilastik-helper/MANIFEST.in
@@ -1,0 +1,1 @@
+include ImageJ_withIlastik/IlastikSetter.java

--- a/recipes/fiji-ilastik-helper/README.md
+++ b/recipes/fiji-ilastik-helper/README.md
@@ -1,0 +1,11 @@
+# fiji-ilastik-helper recipe
+
+With ImageJ, ilastik and the ilastik4ij plugin being installable via conda,
+we want to enable running the ilastik installation from the env via the
+Fiji plugin a flawless experience.
+
+This tiny helper library sets the executable location of ilastik
+to the conda environment when starting ImageJ. That way users don't have to
+configure anything.
+
+Supplies the `ImageJ_withIlastik` entrypoint.

--- a/recipes/fiji-ilastik-helper/meta.yaml
+++ b/recipes/fiji-ilastik-helper/meta.yaml
@@ -1,0 +1,26 @@
+package:
+  name: fiji-ilastik-helper
+  version: 0.0.1
+
+source:
+  path: .
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - ImageJ_withIlastik = ImageJ_withIlastik:main
+  script:
+    - python -m pip install . -vv
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+    # - fiji >=20220414
+    # - ilastik >=1.4.0b29
+
+test:
+  imports:
+    - ImageJ_withIlastik

--- a/recipes/fiji-ilastik-helper/setup.cfg
+++ b/recipes/fiji-ilastik-helper/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+name = fiji-ilastik-helper
+version = 0.0.1
+
+[options.entry_points]
+console_scripts =
+    ImageJ_withIlastik = ImageJ_withIlastik:main
+
+[options]
+include_package_data = True
+packages = find:

--- a/recipes/fiji-ilastik-helper/setup.py
+++ b/recipes/fiji-ilastik-helper/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+
+setup()


### PR DESCRIPTION
proposal for a tiny Python library that would start fiji configured correctly with the ilastik executable location. By making it a noarch Python library, we circumvent any post-install steps that might not be portable.

CC: @lldelisle @NicoKiaru